### PR TITLE
Fix piggyback host creation script

### DIFF
--- a/doc/treasures/auto_piggyback_hosts.sh
+++ b/doc/treasures/auto_piggyback_hosts.sh
@@ -74,7 +74,7 @@ for docker_path in "$PIGGYBACK_DIR"/*/; do
   fi
 
   log "➕ Lege Host $docker_id mit Parent $parent_host an"
-  echo "all_hosts += [\"$docker_id|no-agent|no-ip\"]" >> "$HOSTS_FILE"
+  echo "all_hosts += [\"$docker_id|no-agent|no-ip|/$WATO_FOLDER/\"]" >> "$HOSTS_FILE"
   echo "extra_host_conf.setdefault('parents', []).append((\"$parent_host\", [\"$docker_id\"]))" >> "$HOSTS_FILE"
   ((new++))
 done

--- a/doc/treasures/auto_piggyback_hosts.sh
+++ b/doc/treasures/auto_piggyback_hosts.sh
@@ -75,7 +75,7 @@ for docker_path in "$PIGGYBACK_DIR"/*/; do
 
   log "➕ Lege Host $docker_id mit Parent $parent_host an"
   echo "all_hosts += [\"$docker_id|no-agent|no-ip\"]" >> "$HOSTS_FILE"
-  echo "parents += [(\"$parent_host\", [\"$docker_id\"])]" >> "$HOSTS_FILE"
+  echo "extra_host_conf.setdefault('parents', []).append((\"$parent_host\", [\"$docker_id\"]))" >> "$HOSTS_FILE"
   ((new++))
 done
 shopt -u nullglob


### PR DESCRIPTION
## Summary
- update auto_piggyback_hosts to append parent info using `extra_host_conf`

## Testing
- `bash -n doc/treasures/auto_piggyback_hosts.sh`
- `bin/cmk -U` *(fails: Check_MK can be used only as site user)*

------
https://chatgpt.com/codex/tasks/task_b_684fe2a7d40c8321a6d5e4124f5b8935