### PR TITLE
Add folder suffix to auto piggyback hosts

### DIFF
--- a/doc/treasures/auto_piggyback_hosts.sh
+++ b/doc/treasures/auto_piggyback_hosts.sh
@@ -74,7 +74,7 @@ for docker_path in "$PIGGYBACK_DIR"/*/; do
   fi
 
   log "➕ Lege Host $docker_id mit Parent $parent_host an"
-  echo "all_hosts += [\"$docker_id|no-agent|no-ip\"]" >> "$HOSTS_FILE"
+  echo "all_hosts += [\"$docker_id|no-agent|no-ip|/$WATO_FOLDER/\"]" >> "$HOSTS_FILE"
   echo "parents += [(\"$parent_host\", [\"$docker_id\"])]" >> "$HOSTS_FILE"
   ((new++))
 done


### PR DESCRIPTION
## Summary
- modify piggyback script so generated host entries include WATO folder suffix

## Testing
- `cat sample_test/etc/check_mk/conf.d/wato/piggyback/hosts.mk`

------
https://chatgpt.com/codex/tasks/task_b_684fe2b1e8d883219abb9f110101e660