### PR TITLE
Update .wato creation scripts

### DIFF
--- a/doc/treasures/auto_piggyback_hosts.sh
+++ b/doc/treasures/auto_piggyback_hosts.sh
@@ -37,7 +37,7 @@ mkdir -p "$(dirname "$LOGFILE")"
 
 # create wato folder metadata if missing
 if [ ! -e "$WATO_HOSTDIR/.wato" ]; then
-  echo "{'attributes': {}, 'num_hosts': 0, 'title': '$WATO_FOLDER'}" > "$WATO_HOSTDIR/.wato"
+  echo "{'attributes': {}, 'lock': False, 'num_hosts': 0, 'title': '$WATO_FOLDER'}" > "$WATO_HOSTDIR/.wato"
 fi
 
 # === Check piggyback source ===

--- a/doc/treasures/wato_import.py
+++ b/doc/treasures/wato_import.py
@@ -111,6 +111,6 @@ for folder in folders:
 
     wato_file = open(pathlokal + folder + "/.wato", "w")
     wato_file.write(
-        "{'attributes': {}, 'num_hosts': %d, 'title': '%s'}\n" % (len(folders[folder]), folder)
+        "{'attributes': {}, 'lock': False, 'num_hosts': %d, 'title': '%s'}\n" % (len(folders[folder]), folder)
     )
     wato_file.close()


### PR DESCRIPTION
## Summary
- include `lock` flag in generated `.wato` files

## Testing
- `make test-unit` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684fe2c756948321af9b76e7d2dc6815