### PR TITLE
Validate hosts.mk syntax in auto_piggyback_hosts.sh

### DIFF
--- a/doc/treasures/auto_piggyback_hosts.sh
+++ b/doc/treasures/auto_piggyback_hosts.sh
@@ -87,6 +87,12 @@ for docker_path in "$PIGGYBACK_DIR"/*/; do
 done
 shopt -u nullglob
 
+# === Validate hosts.mk ===
+if ! python -m py_compile "$HOSTS_FILE" >> "$LOGFILE" 2>&1; then
+  log "❌ Syntaxfehler in $HOSTS_FILE"
+  exit 1
+fi
+
 # === Apply configuration ===
 log "🔄 Generiere Konfiguration (cmk -U)"
 if ! $CMK -U >> "$LOGFILE" 2>&1; then


### PR DESCRIPTION
## Summary
- check hosts.mk with Python's bytecode compiler before running cmk -U
- abort and log an error when hosts.mk contains syntax errors

## Testing
- `bash -n doc/treasures/auto_piggyback_hosts.sh`
- `pre-commit run --files doc/treasures/auto_piggyback_hosts.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ffd16c0cc8321967c188640767700