### PR TITLE
Fix host file handling in auto_piggyback_hosts

### DIFF
--- a/doc/treasures/auto_piggyback_hosts.sh
+++ b/doc/treasures/auto_piggyback_hosts.sh
@@ -23,6 +23,12 @@ LOCKFILE="/tmp/create_piggyback_hosts.lock"
 LOGFILE="var/log/piggyback_host_creation.log"
 CLEANUP_AGE_MINUTES=60
 
+# === Options ===
+RESET=false
+if [[ ${1:-} == "--reset" ]]; then
+  RESET=true
+fi
+
 # === Logging ===
 log() {
   echo "$(date '+%F %T') | $1" | tee -a "$LOGFILE"
@@ -40,7 +46,10 @@ touch "$LOCKFILE"
 # === Preparation ===
 mkdir -p "$WATO_HOSTDIR"
 mkdir -p "$(dirname "$LOGFILE")"
-: > "$HOSTS_FILE"
+touch "$HOSTS_FILE"
+if $RESET; then
+  : > "$HOSTS_FILE"
+fi
 
 # create wato folder metadata if missing
 if [ ! -e "$WATO_HOSTDIR/.wato" ]; then


### PR DESCRIPTION
## Summary
- avoid truncating `hosts.mk` every run of `auto_piggyback_hosts.sh`
- add optional `--reset` flag to clear the host file on demand

## Testing
- `make -C tests test-format-shell` *(fails: could not download aspect-cli because the environment has no internet access)*

------
https://chatgpt.com/codex/tasks/task_b_685130a855c8832184b3b5687267ab25