### PR TITLE
Add logging for piggyback dirs

### DIFF
--- a/doc/treasures/auto_piggyback_hosts.sh
+++ b/doc/treasures/auto_piggyback_hosts.sh
@@ -69,6 +69,10 @@ skipped=0
 
 log "📦 Beginne Verarbeitung von Piggyback-Daten..."
 
+# Log which directories are present to troubleshoot missing input
+log "📁 Vorhandene Verzeichnisse:"
+find "$PIGGYBACK_DIR" -mindepth 1 -maxdepth 1 -type d | tee -a "$LOGFILE"
+
 # === Create hosts from piggyback directories ===
 shopt -s nullglob
 for docker_path in "$PIGGYBACK_DIR"/*/; do


### PR DESCRIPTION
## Summary
- log piggyback directories when processing starts

## Testing
- `make -C tests test-ruff` *(fails: network access blocked)*
- `make -C tests test-bandit` *(fails: network access blocked)*
- `make -C tests test-unit` *(fails: network access blocked)*
- `make -C tests test-format-python` *(fails: network access blocked)*
- `make -C tests test-mypy-raw` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6851f5a97b408321aff20c122b4b3420